### PR TITLE
.bash_profile adjustments

### DIFF
--- a/system/.bash_profile
+++ b/system/.bash_profile
@@ -5,7 +5,7 @@
     . /usr/local/share/gitprompt.sh
   fi
 
-export ANDROID_HOME=/Users/wellingtonsantos/Library/Android/sdk
+export ANDROID_HOME=~/Library/Android/sdk
 export PATH+=:$ANDROID_HOME/bin
 export PATH+=:$ANDROID_HOME/tools/
 export PATH+=:$ANDROID_HOME/platform-tools/
@@ -14,7 +14,7 @@ export PATH+=:$ANDROID_HOME/emulator/
 export PATH+=:$ANDROID_HOME/tools/lib
 #export PATH=$PATH:/opt/gradle/gradle-3.5/bin
 #export GRADLE_HOME
-export JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk1.8.0_121.jdk/Contents/Home
+export JAVA_HOME=$(/usr/libexec/java_home)
 
 eval "$(rbenv init -)"
 


### PR DESCRIPTION
I'm finished packing and bored at home, figured I'd make some small changes to make the script more robust :D Also I'm totally going to use this for the mac minis in the future 👍 

Changes:
1. Replaced hardcoded path with shorthand for user's home directory.
2.Java home path replaced with OSX suggested solution. It returns the most recent version (if you have 8,9,10 it will return 10). If you want to always return a specific version (Android and kotlin don't play nice with 10 for example), you can specify the one you need by using `$(/usr/libexec/java_home -v 1.8)` .